### PR TITLE
added the slug to login/register sendTokenResponse

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -210,6 +210,7 @@ const sendTokenResponse = (vendor, statusCode, res) => {
     .json({
       success: true,
       id: vendor.id,
+      slug: vendor.slug,
       token
     });
 };


### PR DESCRIPTION
# Description
Added the business_name's slug to the login/registration response, so we can use it in the browser URI for a particular vendor. 

Fixes # (issue)

## Type of change
-[x] A minor change

## Change Status

- [x] Complete, tested, ready to review and merge

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
