### PR TITLE
vendors/products/:zipcode/:distance?query_param=value

### DIFF
--- a/controllers/products.js
+++ b/controllers/products.js
@@ -13,7 +13,7 @@ exports.getAllProducts = asyncHandler(async (req, res, next) => {
     if (req.params.vendorId) {
         query = Product.find({
             vendor: req.params.vendorId
-        })
+        }).select('-location')
         const products = await query;
 
         res.status(200).json({
@@ -32,8 +32,8 @@ exports.getAllProducts = asyncHandler(async (req, res, next) => {
 exports.getProduct = asyncHandler(async (req, res, next) => {
     const product = await Product.findById(req.params.productId).populate({
         path: 'vendor',
-        select: 'business_name description location'
-    });
+        select: 'business_name description'
+    })
 
     if (!product) {
         return next(new ErrorResponse(`No product with the id of ${req.params.productId}`),
@@ -166,6 +166,6 @@ exports.getProductsInRadius = asyncHandler(async (req, res, next) => {
          data: products
      }); */
 
-    res.status(200).json(res.advancedResults)
+    res.status(200).json(res.advancedResults);
 
 });

--- a/controllers/products.js
+++ b/controllers/products.js
@@ -143,26 +143,29 @@ exports.deleteProduct = asyncHandler(async (req, res, next) => {
 // @route   GET /api/v1.0/products/radius/:zipcode/:distance
 // @access  Public
 exports.getProductsInRadius = asyncHandler(async (req, res, next) => {
-    console.log('getProductInRadius req.params', req.params);
-    console.log('getProductsInRadius res.advancedResults'.red, res.advancedResults)
-    const { zipcode, distance } = req.params;
+    /*  console.log('getProductInRadius req.params', req.params);
+     console.log('getProductsInRadius res.advancedResults'.red, res.advancedResults)
+     const { zipcode, distance } = req.params;
+ 
+     // Get lat/lng from geocoder
+     const loc = await geocoder.geocode(zipcode);
+     const lat = loc[0].latitude;
+     const lng = loc[0].longitude;
+ 
+     // Calc radius using radians
+     // Divide dist by radius of Earth = 3,663 mi / 6,378.1
+     const radius = distance / 3963;
+ 
+     const products = await Product.find({
+         location: { $geoWithin: { $centerSphere: [[lng, lat], radius] } }
+     });
+ 
+     res.status(200).json({
+         success: true,
+         count: products.length,
+         data: products
+     }); */
 
-    // Get lat/lng from geocoder
-    const loc = await geocoder.geocode(zipcode);
-    const lat = loc[0].latitude;
-    const lng = loc[0].longitude;
+    res.status(200).json(res.advancedResults)
 
-    // Calc radius using radians
-    // Divide dist by radius of Earth = 3,663 mi / 6,378.1
-    const radius = distance / 3963;
-
-    const products = await Product.find({
-        location: { $geoWithin: { $centerSphere: [[lng, lat], radius] } }
-    });
-
-    res.status(200).json({
-        success: true,
-        count: products.length,
-        data: products
-    });
 });

--- a/controllers/vendors.js
+++ b/controllers/vendors.js
@@ -16,14 +16,19 @@ exports.getAllVendors = asyncHandler(async (req, res, next) => {
 // @route   GET /api/v1.0/vendors/:id
 // @access  Private
 exports.getVendor = asyncHandler(async (req, res, next) => {
-  const vendor = await Vendor.findById(req.params.vendorId);
+  const vendor = await Vendor.findById(req.params.vendorId).select('-location');
 
   if (!vendor) {
     return next(
       new ErrorResponse(`Vendor not found with id of ${req.params.vendorId}`, 404)
     );
   }
+
   res.status(200).json({ success: true, data: vendor });
+
+
+
+
 });
 // @desc    Create a new vendor
 // @route   POST /api/v1.0/vendors
@@ -77,7 +82,7 @@ exports.deleteVendor = asyncHandler(async (req, res, next) => {
 
 // @desc    Get vendors within a radius
 // @route   GET /api/v1.0/vendors/radius/:zipcode/:distance?query
-// @access  Private
+// @access  Public
 exports.getVendorsInRadius = asyncHandler(async (req, res, next) => {
 
 

--- a/controllers/vendors.js
+++ b/controllers/vendors.js
@@ -76,28 +76,18 @@ exports.deleteVendor = asyncHandler(async (req, res, next) => {
 });
 
 // @desc    Get vendors within a radius
-// @route   GET /api/v1.0/vendors/radius/:zipcode/:distance
+// @route   GET /api/v1.0/vendors/radius/:zipcode/:distance?query
 // @access  Private
 exports.getVendorsInRadius = asyncHandler(async (req, res, next) => {
-  console.log('req params', req.params);
-  const { zipcode, distance } = req.params;
 
-  // Get lat/lng from geocoder
-  const loc = await geocoder.geocode(zipcode);
-  const lat = loc[0].latitude;
-  const lng = loc[0].longitude;
 
-  // Calc radius using radians
-  // Divide dist by radius of Earth = 3,663 mi / 6,378.1
-  const radius = distance / 3963;
 
-  const vendors = await Vendor.find({
-    location: { $geoWithin: { $centerSphere: [[lng, lat], radius] } }
-  });
+  /*  res.status(200).json({
+     success: true,
+     count: vendors.length,
+     data: vendors
+   }); */
 
-  res.status(200).json({
-    success: true,
-    count: vendors.length,
-    data: vendors
-  });
+  res.status(200).json(res.advancedResults)
+
 });

--- a/middleware/advancedResults.js
+++ b/middleware/advancedResults.js
@@ -1,5 +1,9 @@
+const geocoder = require('../utils/geocoder');
+
 const advancedResults = (model, populate) => async (req, res, next) => {
   let query;
+
+
 
   // Making a copy of req.query 
   const reqQuery = { ...req.query };
@@ -10,6 +14,28 @@ const advancedResults = (model, populate) => async (req, res, next) => {
   // Loop over removeFields and delete them from reqQuery if it has them
   removeFields.forEach(param => delete reqQuery[param]);
   console.log('select/sort/page/limit removed reqQuery: ', reqQuery);
+
+
+
+  // check for geocode parameters and add location query object: 
+  if (req.params.zipcode && req.params.distance) {
+    console.log('advancedResults.js, req.params.zipcode'.america, req.params.zipcode, 'req.params.distance: ', req.params.distance)
+    const { zipcode, distance } = req.params;
+
+    // Get lat/lng from geocoder
+    const loc = await geocoder.geocode(zipcode);
+    const lat = loc[0].latitude;
+    const lng = loc[0].longitude;
+
+    // Calc radius using radians
+    // Divide dist by radius of Earth = 3,663 mi / 6,378.1
+    const radius = distance / 3963;
+    reqQuery.location = { $geoWithin: { $centerSphere: [[lng, lat], radius] } }
+
+    console.log('advancedResults.js added location:  '.yellow.bg, reqQuery)
+
+  }
+
 
   let queryStr = JSON.stringify(reqQuery);
   console.log(`advancedResults queryStr: `.yellow, queryStr);
@@ -27,7 +53,7 @@ const advancedResults = (model, populate) => async (req, res, next) => {
     query = query.select(fields);
   }
 
-  // Sort. Something similar as the above select if statement.
+  // Sort. Something similar to the above select if statement.
   if (req.query.sort) {
     const sortBy = req.query.sort.split(',').join(' ');
     query = query.sort(sortBy);
@@ -68,7 +94,7 @@ const advancedResults = (model, populate) => async (req, res, next) => {
       limit
     }
   }
-
+  console.log('advancedMiddleWare.js Final Results', results)
   res.advancedResults = {
     success: true,
     count: results.length,

--- a/middleware/advancedResults.js
+++ b/middleware/advancedResults.js
@@ -61,6 +61,8 @@ const advancedResults = (model, populate) => async (req, res, next) => {
     // default sort. '-' means sort Z-A
     query = query.sort('-createdAt')
   }
+  // remove the location to protect vendor's info
+  query = query.select('-location');
 
   // Pagination
   const page = parseInt(req.query.page, 10) || 1;

--- a/middleware/error.js
+++ b/middleware/error.js
@@ -3,7 +3,7 @@ const ErrorResponse = require('../utils/errorResponse');
 const errorHandler = (err, req, res, next) => {
   let error = { ...err };
 
-  console.log("HERE'S err from error.js: ", err);
+  //console.log("HERE'S err from error.js: ", err);
   error.message = err.message;
 
   // Log to console for dev

--- a/models/Product.js
+++ b/models/Product.js
@@ -31,11 +31,9 @@ const Product_Schema = new mongoose.Schema({
     },
     quantity: {
         type: Number
-    }
-    // category: {
-    //     type: mongoose.Schema.ObjectId,
-    //     ref: 'Category'
-    // }
+    },
+    location: Object
+
 });
 
 
@@ -46,5 +44,7 @@ Product_Schema.pre('remove', async function (next) {
     });
     next();
 });
+
+
 
 module.exports = mongoose.model('Product', Product_Schema);

--- a/models/Vendor.js
+++ b/models/Vendor.js
@@ -93,7 +93,7 @@ const Vendor_Schema = new mongoose.Schema(
       country: String
     }
   },
-  {
+  { //why are these here? See Note on Reverse Populate over function below.
     toJSON: { virtuals: true },
     toObject: { virtuals: true }
   }
@@ -113,7 +113,7 @@ Vendor_Schema.pre('save', async function (next) {
 
 // Sign JWT and return
 Vendor_Schema.methods.getSignedJwtToken = function () {
-  return jwt.sign({ id: this._id }, process.env.JWT_SECRET, { 
+  return jwt.sign({ id: this._id }, process.env.JWT_SECRET, {
     expiresIn: process.env.JWT_EXPIRE
   });
 };
@@ -188,6 +188,14 @@ Vendor_Schema.pre('remove', async function (next) {
   });
   next();
 });
+
+// Note on Reverse Populate:  with virtual. For every Vendor, this function will attach an array of objects of the Vendor's products. To activate this virtual, do Vendor.find('some query').poplulate('products') at the controller level, or do advancedFilter('Vendors', {path: products}) at the route level.
+Vendor_Schema.virtual('products', {
+  ref: 'Product',
+  localField: '_id',
+  foreignField: 'vendor',
+  justOne: false
+})
 
 
 module.exports = mongoose.model('Vendor', Vendor_Schema);

--- a/models/Vendor.js
+++ b/models/Vendor.js
@@ -67,6 +67,10 @@ const Vendor_Schema = new mongoose.Schema(
         'Other'
       ]
     },
+    diet_categories: {
+      type: [String],
+      enum: ['Gluten Free', 'Vegetarian', 'Vegan', 'Keto', 'Dairy Free']
+    },
     created_at: {
       type: Date,
       default: Date.now

--- a/routes/products.js
+++ b/routes/products.js
@@ -25,7 +25,7 @@ router.use('/:productId/product-images', productImagesRouter);
 
 router
     .route('/radius/:zipcode/:distance')
-    .get(advancedResults(Products, { path: 'vendor', select: 'business_name description location' }), getProductsInRadius);
+    .get(advancedResults(Products), getProductsInRadius);
 
 router
     .route('/')

--- a/routes/products.js
+++ b/routes/products.js
@@ -4,7 +4,8 @@ const {
     getProduct,
     addProduct,
     updateProduct,
-    deleteProduct
+    deleteProduct,
+    getProductsInRadius
 } = require('../controllers/products');
 
 const Products = require('../models/Product');
@@ -15,17 +16,20 @@ const { protect } = require('../middleware/auth');
 // Include other resource routers
 const productImagesRouter = require('./productImages');
 
+
 const router = express.Router({ mergeParams: true }); //merging the URL files
 
 // Re-route into other resource route
 router.use('/:productId/product-images', productImagesRouter);
 
+
+router
+    .route('/radius/:zipcode/:distance')
+    .get(advancedResults(Products, { path: 'vendor', select: 'business_name description location' }), getProductsInRadius);
+
 router
     .route('/')
-    .get(advancedResults(Products, {
-        path: 'vendor',
-        select: 'business_name description'
-    }), getAllProducts)
+    .get(advancedResults(Products), getAllProducts)
     .post(protect, addProduct); // POST /api/v1.0/vendors/:vendorId/products
 
 router

--- a/routes/vendors.js
+++ b/routes/vendors.js
@@ -30,17 +30,17 @@ router.use('/:vendorId/product-images', productImageRouter);
 
 router
   .route('/radius/:zipcode/:distance')
-    .get(getVendorsInRadius);
+  .get(advancedResults(Vendor), getVendorsInRadius);
 
 router
   .route('/')
-    .get(advancedResults(Vendor), getAllVendors)
-    .post(protect, createVendor); // POST /api/v1.0/vendors
+  .get(advancedResults(Vendor), getAllVendors)
+  .post(protect, createVendor); // POST /api/v1.0/vendors
 
 router
   .route('/:vendorId')
-    .get(getVendor)
-    .put(protect, updateVendor) // PUT /api/v1.0/vendors/:id
-    .delete(protect, deleteVendor); // DELETE /api/v1.0/vendors/:id
+  .get(getVendor)
+  .put(protect, updateVendor) // PUT /api/v1.0/vendors/:id
+  .delete(protect, deleteVendor); // DELETE /api/v1.0/vendors/:id
 
 module.exports = router;

--- a/routes/vendors.js
+++ b/routes/vendors.js
@@ -39,7 +39,7 @@ router
 
 router
   .route('/:vendorId')
-  .get(getVendor)
+  .get(advancedResults(Vendor), getVendor)
   .put(protect, updateVendor) // PUT /api/v1.0/vendors/:id
   .delete(protect, deleteVendor); // DELETE /api/v1.0/vendors/:id
 


### PR DESCRIPTION
# Description
For Vendors and Products, you can now use the advancedResults middleware when searching by zip code. Example: 
 **/vendors/:zipcode/:distance?diet_categories[in]=Keto**
 
**Important changes to note for Vendor_Schema:** 

Since we are searching the Vendor's resource on the browse page, but want to include Vendors not only by zip code but also filters based on the diets of the products they sell, we have to change the Vendor_Schema to include a diet_categories field. Every time a Vendor creates a new product, they'll have to specify the diet of each product, and we can update the Vendor's diet_categories array as necessary. If we don't do it this way, it seems we'll be forced to map over many products, find the vendor id, do a GET vendor by Id, make sure we haven't already displayed the vendor in the results, etc. 

Other changes on the backend. I concealed the location of Vendors for GET all and get by id requests responses. They still have a location field, in the database, it's just not visible in the response. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
